### PR TITLE
Add CDC analysis tool scaffolding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cdc-tool"
+version = "0.1.0"
+description = "A command line checker for clock-domain crossing safety"
+readme = "README.md"
+authors = [{ name = "CDC Tool Maintainers" }]
+license = { text = "MIT" }
+requires-python = ">=3.9"
+dependencies = [
+    "pyverilog>=1.3",
+    "networkx>=3.0",
+]
+
+[project.optional-dependencies]
+reports = ["tabulate>=0.9"]
+
+[project.scripts]
+cdc-tool = "cdc_tool.cli:main"
+
+[tool.setuptools]
+package-dir = { "" = "src" }
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/cdc_tool/__init__.py
+++ b/src/cdc_tool/__init__.py
@@ -1,0 +1,9 @@
+"""CDC analysis tool package."""
+
+from __future__ import annotations
+
+__all__ = [
+    "__version__",
+]
+
+__version__ = "0.1.0"

--- a/src/cdc_tool/analyzer.py
+++ b/src/cdc_tool/analyzer.py
@@ -1,0 +1,138 @@
+"""Clock domain analysis for the CDC tool."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence, Set
+
+from .parser import DesignGraph, Module, Register
+
+
+@dataclass
+class ClockDomain:
+    """Registers associated with a particular clock signal."""
+
+    name: str
+    registers: Set[str] = field(default_factory=set)
+
+
+@dataclass
+class Crossing:
+    """Represents a single observed clock-domain crossing."""
+
+    module: str
+    signal: str
+    register: str
+    source_domain: Optional[str]
+    target_domain: Optional[str]
+    safe: bool
+    reason: str
+    rule: str = "unsafe_crossing"
+
+
+@dataclass
+class AnalysisReport:
+    """Aggregated data from the analysis stage."""
+
+    clock_domains: Dict[str, ClockDomain]
+    crossings: List[Crossing]
+    disabled_rules: Set[str] = field(default_factory=set)
+
+    def violations(self) -> List[Crossing]:
+        return [
+            crossing
+            for crossing in self.crossings
+            if not crossing.safe and crossing.rule not in self.disabled_rules
+        ]
+
+    def has_violations(self) -> bool:
+        return bool(self.violations())
+
+    def exit_code(self) -> int:
+        return 1 if self.has_violations() else 0
+
+
+def derive_clock_domains(design: DesignGraph) -> Dict[str, ClockDomain]:
+    domains: Dict[str, ClockDomain] = {}
+    for register in design.iter_registers():
+        if register.clock is None:
+            continue
+        domain = domains.setdefault(register.clock, ClockDomain(name=register.clock))
+        domain.registers.add(register.name)
+    return domains
+
+
+def _collect_module_registers(design: DesignGraph) -> Dict[str, Dict[str, Register]]:
+    return {module.name: module.registers for module in design.iter_modules()}
+
+
+def _is_synchronized(register: Register, module: Module) -> bool:
+    """Very small heuristic for detecting two-stage synchronizers."""
+
+    for candidate in module.registers.values():
+        if candidate is register:
+            continue
+        if candidate.clock != register.clock:
+            continue
+        if candidate.drivers == {register.name}:
+            return True
+    return False
+
+
+def classify_crossings(design: DesignGraph) -> List[Crossing]:
+    module_regs = _collect_module_registers(design)
+    crossings: List[Crossing] = []
+
+    for module in design.iter_modules():
+        for register in module.registers.values():
+            target_domain = register.clock
+            for signal in sorted(register.drivers):
+                source_reg = module_regs[module.name].get(signal)
+                source_domain = source_reg.clock if source_reg else None
+                if source_domain == target_domain:
+                    continue
+
+                safe = False
+                reason = "combinational path" if source_domain is None else "async source"
+                if source_domain != target_domain and target_domain is not None:
+                    if _is_synchronized(register, module):
+                        safe = True
+                        reason = "two-stage synchronizer"
+                crossings.append(
+                    Crossing(
+                        module=module.name,
+                        signal=signal,
+                        register=register.name,
+                        source_domain=source_domain,
+                        target_domain=target_domain,
+                        safe=safe,
+                        reason=reason,
+                    )
+                )
+    return crossings
+
+
+def analyze_design(
+    design: DesignGraph,
+    disabled_rules: Optional[Sequence[str]] = None,
+) -> AnalysisReport:
+    """Run the CDC analysis pipeline on a parsed design."""
+
+    disabled_set = set(disabled_rules or [])
+    domains = derive_clock_domains(design)
+    crossings = classify_crossings(design)
+    return AnalysisReport(
+        clock_domains=domains,
+        crossings=crossings,
+        disabled_rules=disabled_set,
+    )
+
+
+__all__ = [
+    "AnalysisReport",
+    "ClockDomain",
+    "Crossing",
+    "analyze_design",
+    "classify_crossings",
+    "derive_clock_domains",
+]

--- a/src/cdc_tool/cli.py
+++ b/src/cdc_tool/cli.py
@@ -1,0 +1,106 @@
+"""Command line interface for the CDC analysis tool."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import sys
+from pathlib import Path
+from typing import List, Optional, Sequence, TextIO
+
+from .analyzer import analyze_design
+from .parser import parse_design
+from .reports import format_report
+
+DEFAULT_RULES = {"unsafe_crossing"}
+
+
+def _expand_globs(patterns: Sequence[str]) -> List[Path]:
+    files: List[Path] = []
+    for pattern in patterns:
+        matches = sorted(glob.glob(pattern, recursive=True))
+        files.extend(Path(match) for match in matches)
+    unique: List[Path] = []
+    seen = set()
+    for path in files:
+        if path not in seen:
+            seen.add(path)
+            unique.append(path)
+    return unique
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Clock-domain crossing analysis tool")
+    parser.add_argument(
+        "inputs",
+        nargs="+",
+        help="Input Verilog files or glob patterns",
+    )
+    parser.add_argument(
+        "--format",
+        default="text",
+        choices=["text", "json"],
+        help="Report format (default: text)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional output file. Defaults to stdout.",
+    )
+    parser.add_argument(
+        "--disable-rule",
+        dest="disabled_rules",
+        action="append",
+        default=[],
+        help="Disable a rule (may be specified multiple times)",
+    )
+    parser.add_argument(
+        "--list-rules",
+        action="store_true",
+        help="List available analysis rules and exit",
+    )
+    return parser
+
+
+def _list_rules(stream: TextIO = sys.stdout) -> None:
+    for rule in sorted(DEFAULT_RULES):
+        print(rule, file=stream)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_argument_parser()
+    args = parser.parse_args(argv)
+
+    if args.list_rules:
+        _list_rules()
+        return 0
+
+    files = _expand_globs(args.inputs)
+    if not files:
+        parser.error("no input files matched the provided patterns")
+
+    try:
+        design = parse_design(files)
+    except FileNotFoundError as exc:
+        parser.error(str(exc))
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"error parsing design: {exc}", file=sys.stderr)
+        return 2
+
+    report = analyze_design(design, disabled_rules=args.disabled_rules)
+    try:
+        rendered = format_report(report, args.format)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered)
+    else:
+        print(rendered)
+
+    return report.exit_code()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    sys.exit(main())

--- a/src/cdc_tool/parser.py
+++ b/src/cdc_tool/parser.py
@@ -1,0 +1,213 @@
+"""Verilog front-end for the CDC analysis tool."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Set
+
+from pyverilog.vparser import ast as vast
+from pyverilog.vparser.parser import parse
+
+
+@dataclass
+class Net:
+    """Representation of a net (wire) in a Verilog module."""
+
+    name: str
+    kind: str = "wire"
+
+
+@dataclass
+class Register:
+    """Representation of a sequential element in a Verilog module."""
+
+    name: str
+    module: str
+    clock: Optional[str] = None
+    drivers: Set[str] = field(default_factory=set)
+
+
+@dataclass
+class Module:
+    """Container holding the signals that make up a Verilog module."""
+
+    name: str
+    ports: Set[str] = field(default_factory=set)
+    nets: Dict[str, Net] = field(default_factory=dict)
+    registers: Dict[str, Register] = field(default_factory=dict)
+
+
+@dataclass
+class DesignGraph:
+    """High-level view of the design produced by the parser."""
+
+    modules: Dict[str, Module]
+
+    def iter_modules(self) -> Iterable[Module]:
+        for module in self.modules.values():
+            yield module
+
+    def iter_registers(self) -> Iterable[Register]:
+        for module in self.iter_modules():
+            yield from module.registers.values()
+
+    def find_register(self, name: str, module: Optional[Module] = None) -> Optional[Register]:
+        """Find a register by name, optionally scoping to a module."""
+
+        if module is not None and name in module.registers:
+            return module.registers[name]
+        for mod in self.modules.values():
+            if name in mod.registers:
+                return mod.registers[name]
+        return None
+
+
+class _IdentifierCollector(vast.NodeVisitor):
+    """Collect identifier names used inside expressions."""
+
+    def __init__(self) -> None:
+        self.names: Set[str] = set()
+
+    def visit_Identifier(self, node: vast.Identifier) -> None:  # pragma: no cover - trivial
+        self.names.add(node.name)
+
+    @classmethod
+    def collect(cls, node: vast.Node) -> Set[str]:
+        collector = cls()
+        collector.visit(node)
+        return collector.names
+
+
+class _DesignBuilder(vast.NodeVisitor):
+    """Traverse the AST to build a :class:`DesignGraph`."""
+
+    def __init__(self) -> None:
+        self.modules: Dict[str, Module] = {}
+        self._module_stack: List[Module] = []
+        self._clock_stack: List[Optional[str]] = []
+
+    # Helpers -----------------------------------------------------------------
+    @property
+    def module(self) -> Module:
+        return self._module_stack[-1]
+
+    @property
+    def current_clock(self) -> Optional[str]:
+        return self._clock_stack[-1] if self._clock_stack else None
+
+    # Visit methods -----------------------------------------------------------
+    def visit_ModuleDef(self, node: vast.ModuleDef) -> None:
+        module = Module(name=node.name)
+        self._module_stack.append(module)
+        try:
+            for item in node.items or []:
+                self.visit(item)
+        finally:
+            self._module_stack.pop()
+            self.modules[module.name] = module
+
+    def visit_Portlist(self, node: vast.Portlist) -> None:  # pragma: no cover - structural
+        for port in node.ports or []:
+            if isinstance(port, vast.Port) and isinstance(port.first, vast.Identifier):
+                self.module.ports.add(port.first.name)
+            elif isinstance(port, vast.Identifier):
+                self.module.ports.add(port.name)
+
+    def visit_Input(self, node: vast.Input) -> None:  # pragma: no cover - structural
+        self.module.ports.add(node.name)
+
+    def visit_Output(self, node: vast.Output) -> None:  # pragma: no cover - structural
+        self.module.ports.add(node.name)
+
+    def visit_Inout(self, node: vast.Inout) -> None:  # pragma: no cover - structural
+        self.module.ports.add(node.name)
+
+    def visit_Decl(self, node: vast.Decl) -> None:
+        for decl in node.list or []:
+            if isinstance(decl, vast.Reg):
+                self.module.registers.setdefault(
+                    decl.name,
+                    Register(name=decl.name, module=self.module.name),
+                )
+            elif isinstance(decl, vast.Wire):
+                self.module.nets.setdefault(
+                    decl.name,
+                    Net(name=decl.name, kind="wire"),
+                )
+
+    def visit_InstanceList(self, node: vast.InstanceList) -> None:  # pragma: no cover - stub
+        # We do not model hierarchy at the moment, but continue traversal.
+        for inst in node.instances or []:
+            self.visit(inst)
+
+    def visit_Always(self, node: vast.Always) -> None:
+        clock = self._extract_clock(node)
+        self._clock_stack.append(clock)
+        try:
+            self.visit(node.statement)
+        finally:
+            self._clock_stack.pop()
+
+    def visit_BlockingSubstitution(self, node: vast.BlockingSubstitution) -> None:
+        self._handle_assignment(node.left, node.right)
+
+    def visit_NonblockingSubstitution(self, node: vast.NonblockingSubstitution) -> None:
+        self._handle_assignment(node.left, node.right)
+
+    # Internal helpers --------------------------------------------------------
+    def _extract_clock(self, node: vast.Always) -> Optional[str]:
+        sens = node.sens_list
+        if isinstance(sens, vast.SensList):
+            for entry in sens.list:
+                if isinstance(entry, vast.Sens) and entry.type in {"posedge", "negedge"}:
+                    if isinstance(entry.sig, vast.Identifier):
+                        return entry.sig.name
+        return None
+
+    def _handle_assignment(self, left: vast.Node, right: vast.Node) -> None:
+        if not isinstance(left, vast.Lvalue):
+            return
+        target = left.var
+        if isinstance(target, vast.Pointer):
+            target = target.var
+        if isinstance(target, vast.Identifier):
+            name = target.name
+        else:
+            return
+
+        register = self.module.registers.get(name)
+        if register is None:
+            return
+        clock = self.current_clock
+        if clock is not None and register.clock is None:
+            register.clock = clock
+        register.drivers.update(_IdentifierCollector.collect(right))
+
+
+def parse_design(files: Sequence[Path]) -> DesignGraph:
+    """Parse the given Verilog files into a :class:`DesignGraph`."""
+
+    if not files:
+        raise ValueError("no input files were provided")
+
+    paths = [Path(path) for path in files]
+    missing = [str(path) for path in paths if not path.exists()]
+    if missing:
+        raise FileNotFoundError(
+            f"the following design files are missing: {', '.join(missing)}"
+        )
+
+    ast, _ = parse([str(path) for path in paths])
+    builder = _DesignBuilder()
+    builder.visit(ast)
+    return DesignGraph(modules=builder.modules)
+
+
+__all__ = [
+    "DesignGraph",
+    "Module",
+    "Net",
+    "Register",
+    "parse_design",
+]

--- a/src/cdc_tool/reports.py
+++ b/src/cdc_tool/reports.py
@@ -1,0 +1,71 @@
+"""Report generation utilities for CDC analysis."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from typing import Any, Dict
+
+from .analyzer import AnalysisReport, Crossing
+
+
+def _crossing_to_dict(crossing: Crossing) -> Dict[str, Any]:
+    data = asdict(crossing)
+    return data
+
+
+def render_text(report: AnalysisReport) -> str:
+    lines = ["Clock Domains:"]
+    if not report.clock_domains:
+        lines.append("  (none detected)")
+    else:
+        for name, domain in sorted(report.clock_domains.items()):
+            registers = ", ".join(sorted(domain.registers)) or "(no registers)"
+            lines.append(f"  {name}: {registers}")
+
+    lines.append("")
+    lines.append("Crossings:")
+    if not report.crossings:
+        lines.append("  (none detected)")
+    else:
+        for crossing in report.crossings:
+            status = "OK" if crossing.safe or crossing.rule in report.disabled_rules else "VIOLATION"
+            lines.append(
+                "  - {module}.{register} <= {signal} ({source}->{target}): {status} [{reason}]".format(
+                    module=crossing.module,
+                    register=crossing.register,
+                    signal=crossing.signal,
+                    source=crossing.source_domain or "comb",
+                    target=crossing.target_domain or "comb",
+                    status=status,
+                    reason=crossing.reason,
+                )
+            )
+    return "\n".join(lines)
+
+
+def render_json(report: AnalysisReport) -> str:
+    payload: Dict[str, Any] = {
+        "clock_domains": {
+            name: sorted(domain.registers)
+            for name, domain in sorted(report.clock_domains.items())
+        },
+        "crossings": [_crossing_to_dict(crossing) for crossing in report.crossings],
+        "disabled_rules": sorted(report.disabled_rules),
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def format_report(report: AnalysisReport, fmt: str) -> str:
+    if fmt == "text":
+        return render_text(report)
+    if fmt == "json":
+        return render_json(report)
+    raise ValueError(f"unsupported report format: {fmt}")
+
+
+__all__ = [
+    "format_report",
+    "render_json",
+    "render_text",
+]


### PR DESCRIPTION
## Summary
- add a setuptools/pyproject configuration with an executable entry point for the CDC tool
- implement a Verilog parser that builds a design graph and an analyzer that classifies crossings
- provide reporting utilities and a CLI that wires parsing, analysis, and reporting together

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d5b13fdebc832eb289811d2daf5938